### PR TITLE
Removed trailing slash that causes issues together with the new AllowedPattern

### DIFF
--- a/index.js
+++ b/index.js
@@ -116,7 +116,7 @@ class CIBuildPlugin {
 
           return value
             .replace(regexRow, (found) => (key !== 'Fn::Sub' ? `###SUB###${found}###/SUB###` : found))
-            .replace(regexArtifact, `${buildPluginArtifact}/`)
+            .replace(regexArtifact, `${buildPluginArtifact}`)
             .replace(regexStage, buildPluginStage)
             .replace(regexRegion, buildPluginRegion);
         }


### PR DESCRIPTION
After adding `AllowedPattern: '.*/'` to `ArtifactPath` slash is duplicated and causes:
```
Error occurred while GetObject. S3 Error Code: NoSuchKey. S3 Error Message: The specified key does not exist. 
```

as ArtifactPath has trailing slash and the template has the trailing slash too:
```
"S3Key":{"Fn::Sub":"${ArtifactPath}/.....
```